### PR TITLE
Stop CrashLoopBack

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ If the resource was unchanged by the apply, a `kubectl rollout restart` is trigg
 
 Maximum time to wait for a rollout to complete. Must be in time format: `60s`, `5m`, `1h`. Requires `KUBE_ROLLOUT: true`.
 
+### `KUBE_STABILITY_WINDOW`
+`integer` — default: `15`
+
+Number of seconds to wait after the rollout reports success before doing a final pod health check. This catches the case where an application crashes shortly after startup: Kubernetes considers the pod "ready" as soon as the container starts, before it has a chance to fail. Set a value higher than your application's startup time to ensure the check is meaningful. Requires `KUBE_ROLLOUT: true`.
+
 <br>
 
 # Rollout behaviour
@@ -114,9 +119,9 @@ When `KUBE_ROLLOUT` is enabled, the action handles two important scenarios:
 
 The rollout monitor runs in the background, allowing the action to respond to cancellation signals from the GitHub Actions UI at any point during the rollout. Cancelling the workflow will stop the rollout immediately instead of leaving the step hanging.
 
-### CrashLoopBackOff detection
+### CrashLoopBackOff detection during rollout
 
-The action polls the pod status every 5 seconds while waiting for the rollout. If any pod enters one of the following states, the pipeline fails immediately without waiting for the full timeout:
+The action polls the pod status every 3 seconds while waiting for the rollout. If any pod enters one of the following states, the pipeline fails immediately without waiting for the full timeout:
 
 | State | Cause |
 |---|---|
@@ -124,6 +129,12 @@ The action polls the pod status every 5 seconds while waiting for the rollout. I
 | `OOMKilled` | Container was terminated due to memory limit |
 | `ImagePullBackOff` | Docker image could not be pulled |
 | `ErrImagePull` | Error while pulling the Docker image |
+
+### Post-rollout stability check
+
+Kubernetes marks a pod as "ready" as soon as the container process starts — before the application has time to crash. In this scenario, the rollout finishes successfully while pods silently start crashing in the background.
+
+After `kubectl rollout status` reports success, the action waits `KUBE_STABILITY_WINDOW` seconds (default: 15) and re-checks all pods. If any pod is in a failed state at that point, the pipeline fails. Set `KUBE_STABILITY_WINDOW` to a value greater than your application's startup time to ensure the check is meaningful.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # kubernetes-eks
 
-Action to apply artifacts files in your [EKS](https://aws.amazon.com/pt/eks/) cluster.
+GitHub Action to apply Kubernetes manifest files in your [EKS](https://aws.amazon.com/pt/eks/) cluster.
 
-This action allows you to apply Kubernetes artifact files by simply pointing to the path where your file is located.
+Point to a file or directory, and this action will apply your manifests, monitor the rollout, and fail fast if something goes wrong — without waiting for the full timeout.
 
 <br>
 
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v4
       - name: Deployment
-        uses: Pablommr/kubernetes-eks@v2.1.1
+        uses: Pablommr/kubernetes-eks@v2.1.2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -29,11 +29,13 @@ jobs:
           KUBE_YAML: path_to_file/file.yml
 ```
 
-
 <br>
 
 # Usage
-To use this action, you just need a user that has permission to apply artifacts in your EKS cluster. For more information, see this [link](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html). Also, set up the necessary environment variables listed below.
+
+To use this action you need an IAM user with permission to apply resources in your EKS cluster. For more information, see the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html).
+
+Set up the environment variables listed below and point to your manifest files via `KUBE_YAML` (individual files) or `FILES_PATH` (directory).
 
 <br>
 
@@ -43,25 +45,29 @@ To use this action, you just need a user that has permission to apply artifacts 
 
 ### `AWS_ACCESS_KEY_ID`
 
-AWS access key id for IAM role.
+AWS access key ID for the IAM role used to authenticate with the cluster.
 
 ### `AWS_SECRET_ACCESS_KEY`
 
-AWS secret key for IAM role. 
+AWS secret access key for the IAM role.
 
 ### `KUBECONFIG`
 
-Environment variable containing the base64-encoded kubeconfig data. Pay attention to the profile name; it must match the AWS_PROFILE_NAME.
+Base64-encoded kubeconfig file. The profile name inside the kubeconfig must match `AWS_PROFILE_NAME`.
 
 ### `KUBE_YAML` or `FILES_PATH`
 
-One of them (or both) must be set. <br><br>
+At least one of them must be set. Both can be used simultaneously.
 
-KUBE_YAML is the path of <b>file</b> to file used to create/update the resource. This env can be an array with more then 1 file. (I.e. kubernetes/deployment.yml,artifacts/configmap.yaml )<br><br>
+**`KUBE_YAML`** — path to one or more individual manifest files, separated by commas.
+```
+KUBE_YAML: kubernetes/deployment.yml,artifacts/configmap.yaml
+```
 
-FILES_PATH is the path of the <b>directory</b> where the files are located. All files in this current directory will be applied.<br><br>
-
-The files must be with *.yaml or *.yml extensions.
+**`FILES_PATH`** — path to a directory. All `.yaml` and `.yml` files directly inside the directory will be applied. Use `SUBPATH: true` to include subdirectories.
+```
+FILES_PATH: kubernetes
+```
 
 <br>
 
@@ -69,62 +75,100 @@ The files must be with *.yaml or *.yml extensions.
 
 ### `AWS_PROFILE_NAME`
 
-Profile name to be configured. If not passed, this env assume the value 'default'
+AWS credentials profile name to be written to `~/.aws/credentials`. Defaults to `default`.
 
 ### `ENVSUBST`
-(boolean)
+`boolean` — default: `false`
 
-Whether to run envsubst to substitute environment variables inside the file in KUBE_YAML. Your variable inside your file need begin with "$". If not passed, this env assume the value 'false'
+When `true`, substitutes environment variables inside the manifest files before applying them. Variables must be declared with `$` prefix (e.g., `$IMAGE_TAG`). Useful for injecting dynamic values such as image tags at deploy time.
 
 ### `SUBPATH`
-(boolean)
+`boolean` — default: `false`
 
-If you use path in env FILES_PATH, you can set this env to true to apply files in subdirectory. Default value is false.
+When `true` and using `FILES_PATH`, applies manifest files found in subdirectories as well. When `false`, only files at the top level of `FILES_PATH` are applied.
 
 ### `CONTINUE_IF_FAIL`
-(boolean)
+`boolean` — default: `false`
 
-If you use path in env FILES_PATH, you can set this env to true to continue applying files in case of fail in one file. Default value is false.
+When `true`, the action continues processing remaining files even if one apply or rollout fails. The pipeline will still exit with an error code at the end if any failure occurred. When `false`, the action stops immediately on the first failure.
 
 ### `KUBE_ROLLOUT`
-(boolean)
+`boolean` — default: `true`
 
-Whether to watch the status of the latest rollout until it's done. The rollout only works for Deployment, StatefulSet, or DaemonSet resources and will only be executed if the Pods applied by KUBE_YAML finalize with an unchanged status. Default value is true.
+When `true`, the action watches the rollout status after each apply for resources that manage Pods (`Deployment`, `ReplicaSet`, `DaemonSet`, `Pod`). The rollout is monitored until it completes successfully, fails, or reaches `KUBE_ROLLOUT_TIMEOUT`.
+
+If the resource was unchanged by the apply, a `kubectl rollout restart` is triggered automatically to ensure the latest configuration or image is rolled out.
 
 ### `KUBE_ROLLOUT_TIMEOUT`
-(String)
+`string` — default: `20m`
 
-Timeout to KUBE_ROLLOUT. This env must be in time format. (i.e.: 60s, 5m, 1h) and KUBE_ROLLOUT must be true. Defaul value is 20m.
+Maximum time to wait for a rollout to complete. Must be in time format: `60s`, `5m`, `1h`. Requires `KUBE_ROLLOUT: true`.
+
+<br>
+
+# Rollout behaviour
+
+When `KUBE_ROLLOUT` is enabled, the action handles two important scenarios:
+
+### Workflow cancellation
+
+The rollout monitor runs in the background, allowing the action to respond to cancellation signals from the GitHub Actions UI at any point during the rollout. Cancelling the workflow will stop the rollout immediately instead of leaving the step hanging.
+
+### CrashLoopBackOff detection
+
+The action polls the pod status every 5 seconds while waiting for the rollout. If any pod enters one of the following states, the pipeline fails immediately without waiting for the full timeout:
+
+| State | Cause |
+|---|---|
+| `CrashLoopBackOff` | Container is crashing repeatedly on startup |
+| `OOMKilled` | Container was terminated due to memory limit |
+| `ImagePullBackOff` | Docker image could not be pulled |
+| `ErrImagePull` | Error while pulling the Docker image |
+
+<br>
+
+# Application order
+
+Manifests are applied in the following order to respect Kubernetes resource dependencies:
+
+1. **Namespace** — must exist before any other resource.
+2. **All other resource types** (ConfigMap, Service, Ingress, etc.) — applied without rollout monitoring.
+3. **Pod-managing resources** (Deployment, ReplicaSet, DaemonSet, Pod) — applied with rollout monitoring when `KUBE_ROLLOUT: true`.
+4. **ScaledObject** (KEDA) — applied last, as it references a Deployment that must already exist.
 
 <br>
 
 # Use case
 
-Let's suppose you need to apply three artifacts in your EKS: one Deployment, one Service, and one ConfigMap. All your Kubernetes artifacts are inside the kubernetes folder, like this:
+Let's suppose you need to apply three artifacts in your EKS: one Deployment, one Service, and one ConfigMap. All your Kubernetes manifests are inside the `kubernetes` folder:
 
 ```
 ├── README.md
 ├── app
 |  └── files
 ├── kubernetes
-│   ├── deployment.yaml
-│   ├── envs
-│   │   ├── prod
-│   │   │   └── configmap.yaml
-│   │   └── staging
-│   │       └── configmap.yaml
-│   └── service.yaml
+│   ├── deployment.yaml
+│   ├── envs
+│   │   ├── prod
+│   │   │   └── configmap.yaml
+│   │   └── staging
+│   │       └── configmap.yaml
+│   └── service.yaml
 └── another_files
 ```
-You've already set up your build and just need to apply it in Kubernetes. Even if the only change was in the ConfigMap, you will need to roll out the pods. You want to apply just the prod ConfigMap, and you also need to substitute variables inside deployment.yml for some other value. Let's assume you want to change the image tag, so you can name your tag in the image line in deployment.yml with a placeholder, for example $IMAGE_TAG, like this:
 
-```
+You want to:
+- Apply `deployment.yaml` and `service.yaml` from the `kubernetes` folder (not subdirectories).
+- Apply only the prod `configmap.yaml` individually.
+- Substitute the image tag dynamically using `ENVSUBST`.
+
+In `deployment.yaml`, declare the image tag as a placeholder:
+
+```yaml
 image: nginx:$IMAGE_TAG
 ```
 
-Then, pass the IMAGE_TAG as an environment variable with the desired value.
-
-You can configure your pipeline like this:
+Then configure your pipeline:
 
 ```yml
 name: Build
@@ -149,21 +193,27 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v4
       - name: Deploy
-        uses: Pablommr/kubernetes-eks@v2.1.1
+        uses: Pablommr/kubernetes-eks@v2.1.2
         env:
           FILES_PATH: kubernetes
           KUBE_YAML: kubernetes/envs/prod/configmap.yaml
-          SUBPATH: false #Defaul value
+          SUBPATH: false
           ENVSUBST: true
           KUBE_ROLLOUT: true
+          KUBE_ROLLOUT_TIMEOUT: 10m
           IMAGE_TAG: 1.21.6
 ```
 
-In this setup, with FILES_PATH: kubernetes, you will apply all files under the kubernetes path (deployment.yaml and service.yaml), but none under env, since SUBPATH is set to false. However, you will still apply the ConfigMap with KUBE_YAML: kubernetes/envs/configmap.yaml.
+With `FILES_PATH: kubernetes` and `SUBPATH: false`, only `deployment.yaml` and `service.yaml` are applied from the directory. The prod ConfigMap is applied separately via `KUBE_YAML`. The `$IMAGE_TAG` placeholder in `deployment.yaml` is replaced with `1.21.6` before applying.
 
 <br>
 
 # Change Log
+
+## v2.1.2
+
+- Rollout cancellation: the pipeline now responds immediately to workflow cancellation from the GitHub Actions UI during a rollout, instead of waiting for the current step to finish.
+- CrashLoopBackOff fail fast: if any pod enters a failed state (`CrashLoopBackOff`, `OOMKilled`, `ImagePullBackOff`, `ErrImagePull`) during a rollout, the pipeline fails immediately without waiting for the timeout.
 
 ## v2.1.1
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -347,11 +347,45 @@ run_rollout_status () {
   # Necessário para filtrar apenas os pods deste deploy no loop de monitoramento.
   # Pods são ignorados aqui pois eles mesmos são monitorados diretamente abaixo.
   local selector=""
+  # Selector efetivo usado nos health checks. Para Deployments, é refinado para
+  # incluir apenas pods do novo ReplicaSet (ver bloco abaixo).
+  local active_selector=""
   if [ "$kind_lower" != "pod" ]; then
     sleep 2  # Aguarda brevemente para o recurso estar visível na API do Kubernetes.
     selector=$(kubectl get "$kind_lower" "$resource_name" -n "$namespace" \
       -o jsonpath='{.spec.selector.matchLabels}' 2>/dev/null \
       | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")' 2>/dev/null)
+
+    # Para Deployments: restringe o health check apenas aos pods do novo ReplicaSet,
+    # evitando falsos positivos causados por pods do ReplicaSet anterior que ainda
+    # estão em CrashLoopBackOff enquanto o novo rollout já está saudável.
+    #
+    # A lógica: busca o ReplicaSet cuja anotação deployment.kubernetes.io/revision
+    # corresponde à revisão atual do Deployment e extrai seu pod-template-hash.
+    # Esse hash é adicionado ao selector para filtrar apenas os pods novos.
+    if [ "$kind_lower" == "deployment" ] && [ -n "$selector" ]; then
+      local deploy_revision
+      deploy_revision=$(kubectl get deployment "$resource_name" -n "$namespace" \
+        -o jsonpath='{.metadata.annotations.deployment\.kubernetes\.io/revision}' 2>/dev/null)
+
+      if [ -n "$deploy_revision" ]; then
+        local new_hash
+        new_hash=$(kubectl get rs -n "$namespace" -l "$selector" \
+          -o jsonpath="{.items[?(@.metadata.annotations['deployment\.kubernetes\.io/revision']=='$deploy_revision')].metadata.labels.pod-template-hash}" \
+          2>/dev/null)
+
+        if [ -n "$new_hash" ]; then
+          active_selector="$selector,pod-template-hash=$new_hash"
+          echo "Monitoring pods from new ReplicaSet (pod-template-hash=$new_hash)."
+        fi
+      fi
+    fi
+
+    # Para outros tipos (DaemonSet, ReplicaSet) ou se não foi possível obter o hash,
+    # usa o selector completo do recurso.
+    if [ -z "$active_selector" ]; then
+      active_selector="$selector"
+    fi
   fi
 
   # Loop de monitoramento: verifica a cada 3 segundos enquanto o rollout está rodando.
@@ -363,9 +397,9 @@ run_rollout_status () {
   #   - Error: container encerrou com código de erro (fase transiente antes do CrashLoopBackOff).
   while kill -0 "$ROLLOUT_PID" 2>/dev/null; do
     local crash_info=""
-    if [ -n "$selector" ]; then
-      # Para Deployments, DaemonSets e ReplicaSets: busca pods pelo selector do recurso.
-      crash_info=$(kubectl get pods -n "$namespace" -l "$selector" --no-headers 2>/dev/null \
+    if [ -n "$active_selector" ]; then
+      # Verifica apenas os pods do novo ReplicaSet (ou selector completo para outros tipos).
+      crash_info=$(kubectl get pods -n "$namespace" -l "$active_selector" --no-headers 2>/dev/null \
         | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull|Error)" | head -3)
     elif [ "$kind_lower" == "pod" ]; then
       # Para Pods standalone: verifica diretamente o status do pod pelo nome.
@@ -373,7 +407,7 @@ run_rollout_status () {
         | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull|Error)" | head -1)
     fi
 
-    # Se algum pod falhou, interrompe o rollout imediatamente (fail fast).
+    # Se algum pod do novo ReplicaSet falhou, interrompe o rollout imediatamente (fail fast).
     if [ -n "$crash_info" ]; then
       echo ""
       echo "ERROR: Pod(s) detected in failed state — failing fast:"
@@ -404,13 +438,14 @@ run_rollout_status () {
   # Aguarda KUBE_STABILITY_WINDOW segundos e re-verifica o estado dos pods.
   # Captura o cenário em que a aplicação crashou logo após o startup e o
   # rollout reportou sucesso antes dos pods entrarem em Error/CrashLoopBackOff.
+  # Usa o mesmo active_selector para verificar apenas os pods do novo ReplicaSet.
   # -------------------------------------------------------------------------
   echo "Rollout reported success. Running stability check (${KUBE_STABILITY_WINDOW}s)..."
   sleep "$KUBE_STABILITY_WINDOW"
 
   local post_crash_info=""
-  if [ -n "$selector" ]; then
-    post_crash_info=$(kubectl get pods -n "$namespace" -l "$selector" --no-headers 2>/dev/null \
+  if [ -n "$active_selector" ]; then
+    post_crash_info=$(kubectl get pods -n "$namespace" -l "$active_selector" --no-headers 2>/dev/null \
       | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull|Error)" | head -3)
   elif [ "$kind_lower" == "pod" ]; then
     post_crash_info=$(kubectl get pod "$resource_name" -n "$namespace" --no-headers 2>/dev/null \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,6 +91,18 @@ if ! [[ $KUBE_ROLLOUT_TIMEOUT =~ ^[0-9]+[smh]$ ]]; then
     exit 1
 fi
 
+# KUBE_STABILITY_WINDOW define quantos segundos aguardar após o rollout concluir antes
+# de re-verificar os pods. Necessário para detectar aplicações que crasham após o startup
+# (o Kubernetes considera o pod "ready" antes do crash acontecer). Deve ser um inteiro.
+if [ -z "$KUBE_STABILITY_WINDOW" ]; then
+  KUBE_STABILITY_WINDOW=15
+  echo 'Env KUBE_STABILITY_WINDOW is empty! Using default 15s.'
+fi
+if ! [[ $KUBE_STABILITY_WINDOW =~ ^[0-9]+$ ]]; then
+    echo "Erro: KUBE_STABILITY_WINDOW must be a positive integer (seconds). (i.e.: 15, 30)"
+    exit 1
+fi
+
 echo ""
 
 # -----------------------------------------------------------------------------
@@ -284,18 +296,25 @@ envSubstitution () {
 # -----------------------------------------------------------------------------
 # run_rollout_status
 #
-# Substitui a chamada direta de "kubectl rollout status" para resolver dois
+# Substitui a chamada direta de "kubectl rollout status" para resolver três
 # problemas:
 #
 #   1. CANCELAMENTO PELO GITHUB ACTIONS:
 #      O kubectl roda em background. Um trap em SIGTERM/SIGINT mata o processo
 #      e encerra o script quando o usuário cancela o workflow pela UI.
 #
-#   2. DETECÇÃO RÁPIDA DE CRASHLOOPBACKOFF:
-#      Enquanto o rollout está pendente, um loop verifica a cada 5 segundos
+#   2. DETECÇÃO RÁPIDA DE CRASHLOOPBACKOFF DURANTE O ROLLOUT:
+#      Enquanto o rollout está pendente, um loop verifica a cada 3 segundos
 #      se algum pod do recurso entrou em estado de falha. Se detectado, o
 #      kubectl em background é morto e a função retorna erro imediatamente,
 #      sem aguardar o timeout completo.
+#
+#   3. STABILITY CHECK PÓS-ROLLOUT:
+#      O Kubernetes considera um pod "ready" assim que o container inicia,
+#      antes que a aplicação tenha chance de crashar. Se a aplicação falha
+#      alguns segundos após o startup, o rollout reporta sucesso e os pods
+#      só entram em Error/CrashLoopBackOff depois. Após o rollout concluir,
+#      aguarda KUBE_STABILITY_WINDOW segundos e re-verifica os pods.
 #
 # Parâmetros:
 #   $1 — caminho do arquivo YAML do recurso
@@ -335,21 +354,23 @@ run_rollout_status () {
       | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")' 2>/dev/null)
   fi
 
-  # Loop de monitoramento: verifica a cada 5 segundos enquanto o rollout está rodando.
+  # Loop de monitoramento: verifica a cada 3 segundos enquanto o rollout está rodando.
+  # Intervalo curto para capturar crashes rápidos antes do rollout avançar para o próximo pod.
   # Estados de falha monitorados:
   #   - CrashLoopBackOff: container falha repetidamente ao iniciar.
   #   - OOMKilled: container encerrado por falta de memória.
   #   - ImagePullBackOff / ErrImagePull: imagem Docker não pode ser baixada.
+  #   - Error: container encerrou com código de erro (fase transiente antes do CrashLoopBackOff).
   while kill -0 "$ROLLOUT_PID" 2>/dev/null; do
     local crash_info=""
     if [ -n "$selector" ]; then
       # Para Deployments, DaemonSets e ReplicaSets: busca pods pelo selector do recurso.
       crash_info=$(kubectl get pods -n "$namespace" -l "$selector" --no-headers 2>/dev/null \
-        | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull)" | head -3)
+        | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull|Error)" | head -3)
     elif [ "$kind_lower" == "pod" ]; then
       # Para Pods standalone: verifica diretamente o status do pod pelo nome.
       crash_info=$(kubectl get pod "$resource_name" -n "$namespace" --no-headers 2>/dev/null \
-        | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull)" | head -1)
+        | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull|Error)" | head -1)
     fi
 
     # Se algum pod falhou, interrompe o rollout imediatamente (fail fast).
@@ -362,16 +383,49 @@ run_rollout_status () {
       trap - SIGTERM SIGINT
       return 1
     fi
-    sleep 5
+    sleep 3
   done
 
   # Aguarda o kubectl terminar e captura o código de saída (0 = sucesso, !0 = falha/timeout).
   wait "$ROLLOUT_PID"
   local rollout_exit=$?
 
-  # Remove o trap após o rollout concluir normalmente para não afetar outros comandos.
+  # Remove o trap após o rollout concluir para não afetar outros comandos.
   trap - SIGTERM SIGINT
-  return $rollout_exit
+
+  # Se o próprio kubectl reportou falha (ex: timeout), retorna imediatamente.
+  if [ $rollout_exit -ne 0 ]; then
+    return $rollout_exit
+  fi
+
+  # -------------------------------------------------------------------------
+  # Stability check pós-rollout.
+  #
+  # Aguarda KUBE_STABILITY_WINDOW segundos e re-verifica o estado dos pods.
+  # Captura o cenário em que a aplicação crashou logo após o startup e o
+  # rollout reportou sucesso antes dos pods entrarem em Error/CrashLoopBackOff.
+  # -------------------------------------------------------------------------
+  echo "Rollout reported success. Running stability check (${KUBE_STABILITY_WINDOW}s)..."
+  sleep "$KUBE_STABILITY_WINDOW"
+
+  local post_crash_info=""
+  if [ -n "$selector" ]; then
+    post_crash_info=$(kubectl get pods -n "$namespace" -l "$selector" --no-headers 2>/dev/null \
+      | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull|Error)" | head -3)
+  elif [ "$kind_lower" == "pod" ]; then
+    post_crash_info=$(kubectl get pod "$resource_name" -n "$namespace" --no-headers 2>/dev/null \
+      | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull|Error)" | head -1)
+  fi
+
+  if [ -n "$post_crash_info" ]; then
+    echo ""
+    echo "ERROR: Post-rollout stability check failed — pod(s) entered failed state after rollout:"
+    echo "$post_crash_info"
+    return 1
+  fi
+
+  echo "Stability check passed."
+  return 0
 }
 
 # -----------------------------------------------------------------------------

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
 
+# =============================================================================
+# entrypoint.sh
+#
+# Script principal da GitHub Action kubernetes-eks.
+# Responsável por:
+#   1. Validar as variáveis de ambiente obrigatórias e opcionais.
+#   2. Configurar as credenciais AWS e o kubeconfig.
+#   3. Descobrir e classificar os manifests YAML por tipo de recurso.
+#   4. Aplicar os manifests no cluster EKS respeitando a ordem de dependência.
+#   5. Monitorar o rollout dos recursos que possuem Pods, detectando falhas
+#      rapidamente (CrashLoopBackOff) e permitindo cancelamento pelo GitHub Actions.
+# =============================================================================
+
 #set -e
 #
 echo ""
 echo "Checking ENVs..."
 
-#Check if ENVs is fulfiled
+# -----------------------------------------------------------------------------
+# Validação das variáveis de ambiente obrigatórias.
+# O script falha imediatamente se qualquer uma delas estiver ausente,
+# pois sem elas não é possível autenticar na AWS nem no cluster.
+# -----------------------------------------------------------------------------
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
   echo 'Env AWS_ACCESS_KEY_ID is empty! Please, fulfil it with your aws access key...'
   exit 1
@@ -16,6 +33,7 @@ elif [ -z "$KUBECONFIG" ]; then
   echo 'Env KUBECONFIG is empty! Please, fulfil it with your kubeconfig in base64...'
   exit 1
 elif [ -z "$KUBE_YAML" ]; then
+  # Aceita FILES_PATH como alternativa a KUBE_YAML para apontar um diretório inteiro.
   if [ -z "$FILES_PATH" ]; then
     echo "Envs KUBE_YAML or FILES_PATH is empty or file doesn't exist! Please, fulfil it with full path where your file is..."
     exit 1
@@ -25,30 +43,49 @@ elif [ -z "$KUBE_YAML" ]; then
   fi
 fi
 
+# -----------------------------------------------------------------------------
+# Valores padrão para variáveis opcionais.
+# Cada bloco aplica o default apenas quando a variável não foi fornecida
+# ou tem um valor inválido, garantindo comportamento previsível.
+# -----------------------------------------------------------------------------
+
+# Perfil AWS a ser usado no ~/.aws/credentials (default: "default").
 if [ -z "$AWS_PROFILE_NAME" ]; then
   AWS_PROFILE_NAME='default'
   echo 'Env AWS_PROFILE_NAME is empty! Using default.'
 fi
+
+# ENVSUBST=true faz o script substituir variáveis de ambiente nos YAMLs antes de aplicá-los.
 if [ "$ENVSUBST" != "true" ] && [ "$SUBPATH" != "ENVSUBST" ]; then
   ENVSUBST=false
   echo 'Env ENVSUBST is empty! Using default=false.'
 fi
+
+# SUBPATH=true permite que o script busque YAMLs recursivamente em subdiretórios.
 if [ "$SUBPATH" != "true" ] && [ "$SUBPATH" != "false" ]; then
   SUBPATH=false
   echo 'Env SUBPATH is empty or wrong value! Using default=false.'
 fi
+
+# CONTINUE_IF_FAIL=true faz o script continuar mesmo que um apply/rollout falhe.
 if [ "$CONTINUE_IF_FAIL" != "true" ] && [ "$CONTINUE_IF_FAIL" != "false" ]; then
   CONTINUE_IF_FAIL=false
   echo 'Env CONTINUE_IF_FAIL is empty! Using default=false.'
 fi
+
+# KUBE_ROLLOUT=true habilita o acompanhamento do rollout após cada apply.
 if [ "$KUBE_ROLLOUT" != "true" ] && [ "$KUBE_ROLLOUT" != "false" ]; then
   KUBE_ROLLOUT=true
   echo 'Env KUBE_ROLLOUT is empty! Using default=true.'
 fi
+
+# KUBE_ROLLOUT_TIMEOUT define quanto tempo aguardar o rollout antes de falhar (default: 20m).
 if [ -z "$KUBE_ROLLOUT_TIMEOUT" ]; then
   KUBE_ROLLOUT_TIMEOUT='20m'
   echo 'Env KUBE_ROLLOUT_TIMEOUT is empty! Using default 20m.'
 fi
+
+# Valida o formato do timeout: deve ser um número seguido de s, m ou h (ex: 60s, 5m, 1h).
 if ! [[ $KUBE_ROLLOUT_TIMEOUT =~ ^[0-9]+[smh]$ ]]; then
     echo "Erro: O KUBE_ROLLOUT_TIMEOUT must be in time format. (i.e.: 60s, 5m, 1h)."
     exit 1
@@ -56,25 +93,39 @@ fi
 
 echo ""
 
+# -----------------------------------------------------------------------------
+# Configuração das credenciais AWS e do kubeconfig.
+# Os valores chegam como variáveis de ambiente e são gravados nos paths
+# esperados pelo AWS CLI e pelo kubectl, respectivamente.
+# -----------------------------------------------------------------------------
 mkdir -p ~/.aws
 mkdir -p ~/.kube
 
 AWS_CREDENTIALS_PATH='~/.aws/credentials'
 KUBECONFIG_PATH='~/.kube/config'
 
-#fulfiling the files
+# Grava o arquivo de credenciais AWS com o perfil configurado.
 echo "[$AWS_PROFILE_NAME]" > $(eval echo $AWS_CREDENTIALS_PATH)
 echo "aws_access_key_id = $AWS_ACCESS_KEY_ID" >> $(eval echo $AWS_CREDENTIALS_PATH)
 echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY" >> $(eval echo $AWS_CREDENTIALS_PATH)
 
+# Decodifica o kubeconfig (enviado em base64) e salva no path padrão do kubectl.
 echo "$KUBECONFIG" |base64 -d > $(eval echo $KUBECONFIG_PATH)
 
-#Unset var to make sure ther are no conflict
+# Remove a variável KUBECONFIG do ambiente para evitar conflito com o arquivo gravado acima.
 unset KUBECONFIG
 
 
 ###================================
-#Functions
+# FUNÇÕES
+###================================
+
+# -----------------------------------------------------------------------------
+# check_directories_and_files
+#
+# Valida que cada diretório informado existe e contém pelo menos um arquivo
+# .yaml ou .yml. Respeita a flag SUBPATH para busca recursiva ou não.
+# -----------------------------------------------------------------------------
 check_directories_and_files() {
   local dirs=("$@")
   for dir in "${dirs[@]}"; do
@@ -101,6 +152,12 @@ check_directories_and_files() {
   done
 }
 
+# -----------------------------------------------------------------------------
+# check_files_exist
+#
+# Verifica que cada arquivo informado existe no filesystem e chama
+# check_yaml_files para validar a extensão.
+# -----------------------------------------------------------------------------
 check_files_exist() {
   local files=("$@")
   for file in "${files[@]}"; do
@@ -114,6 +171,12 @@ check_files_exist() {
   done
 }
 
+# -----------------------------------------------------------------------------
+# check_yaml_files
+#
+# Garante que o arquivo tem extensão .yaml ou .yml. Outras extensões são
+# rejeitadas para evitar que arquivos não-Kubernetes sejam aplicados.
+# -----------------------------------------------------------------------------
 check_yaml_files() {
   local files=("$@")
   for file in "${files[@]}"; do
@@ -125,7 +188,19 @@ check_yaml_files() {
   done
 }
 
-#Cria Json com arquivos a serem aplicados
+# -----------------------------------------------------------------------------
+# createJsonFiles
+#
+# Lê um arquivo YAML, extrai o campo .kind e o adiciona ao FILES_JSON,
+# que é um objeto indexado por tipo de recurso (ex: Deployment, Service...).
+#
+# Caso o arquivo contenha múltiplos recursos separados por "---", usa csplit
+# para dividi-lo em arquivos individuais e processa cada um recursivamente.
+#
+# Parâmetros:
+#   $1 — caminho do arquivo YAML
+#   $2 — nome original do arquivo (usado no resumo do GitHub Actions)
+# -----------------------------------------------------------------------------
 createJsonFiles () {
   #Local do arquivo a ser aplicado
   local file="$1"
@@ -137,11 +212,14 @@ createJsonFiles () {
   local folder_split='csplit'
   local tmp_dir='tmp_dir'
 
-  #Verifica se tem '---' na primeira linha, e caso tenha, remove
+  # Remove o separador "---" da primeira linha, caso exista, pois o csplit
+  # usa "---" como delimitador e uma linha inicial causaria um arquivo vazio.
   if [ "$(head -1 $file)" == "---" ]; then
     sed -i '1d' $file
   fi
 
+  # Se o arquivo contém múltiplos recursos (separados por "---"), divide-o
+  # em arquivos individuais usando csplit e processa cada um recursivamente.
   if [ $(grep "^---$" "$file" | wc -l) -ne 0 ]; then
     #cria o diretório csplit
     mkdir -p $folder_split
@@ -163,13 +241,14 @@ createJsonFiles () {
     #Remove arquivos locais para não haver repetição na próxima iteração
     rm -rf $tmp_dir
 
-    #Percorre os novos arquivos
+    # Chama recursivamente para cada arquivo gerado, substituindo o path
+    # tmp_dir pelo path definitivo csplit.
     for j in ${NEW_FILES_YAML[@]}; do
       createJsonFiles "$(echo -n $j | sed 's/tmp_dir/csplit/')" $file
     done
 
   else
-    #Verifica se a env que printa está vazia
+    # Arquivo simples (recurso único): registra no FILES_JSON sob a chave do kind.
     if [ -z "$name_file" ]; then
       local name_file="$file"
     fi
@@ -179,6 +258,16 @@ createJsonFiles () {
   fi
 }
 
+# -----------------------------------------------------------------------------
+# envSubstitution
+#
+# Substitui no arquivo YAML todas as ocorrências de variáveis de ambiente
+# no formato $NOME_DA_VAR pelo valor atual. Útil para injetar valores
+# dinâmicos (ex: tag da imagem) em tempo de deploy.
+#
+# Parâmetros:
+#   $1 — caminho do arquivo YAML a ser modificado in-place
+# -----------------------------------------------------------------------------
 envSubstitution () {
   local file="$1"
 
@@ -192,6 +281,109 @@ envSubstitution () {
   done
 }
 
+# -----------------------------------------------------------------------------
+# run_rollout_status
+#
+# Substitui a chamada direta de "kubectl rollout status" para resolver dois
+# problemas:
+#
+#   1. CANCELAMENTO PELO GITHUB ACTIONS:
+#      O kubectl roda em background. Um trap em SIGTERM/SIGINT mata o processo
+#      e encerra o script quando o usuário cancela o workflow pela UI.
+#
+#   2. DETECÇÃO RÁPIDA DE CRASHLOOPBACKOFF:
+#      Enquanto o rollout está pendente, um loop verifica a cada 5 segundos
+#      se algum pod do recurso entrou em estado de falha. Se detectado, o
+#      kubectl em background é morto e a função retorna erro imediatamente,
+#      sem aguardar o timeout completo.
+#
+# Parâmetros:
+#   $1 — caminho do arquivo YAML do recurso
+#   $2 — kind do recurso (ex: "Deployment")
+#   $3 — nome do recurso (metadata.name)
+# -----------------------------------------------------------------------------
+run_rollout_status () {
+  local file="$1"
+  local resource_kind="$2"   # e.g. "Deployment"
+  local resource_name="$3"
+
+  # Converte o kind para lowercase para uso nos comandos kubectl (ex: "deployment").
+  local kind_lower
+  kind_lower=$(echo "$resource_kind" | tr '[:upper:]' '[:lower:]')
+
+  # Lê o namespace do manifest; usa "default" caso não esteja definido.
+  local namespace
+  namespace=$(yq eval '.metadata.namespace // "default"' "$file")
+
+  # Inicia o kubectl rollout status em background para que sinais externos
+  # possam interrompê-lo sem travar o script.
+  kubectl rollout status --filename "$file" --timeout="$KUBE_ROLLOUT_TIMEOUT" &
+  local ROLLOUT_PID=$!
+
+  # Configura trap para SIGTERM e SIGINT (enviados pelo GitHub Actions ao cancelar
+  # o workflow). Ao receber o sinal, mata o kubectl em background e encerra o script.
+  trap "echo 'Pipeline cancelled. Stopping rollout...'; kill $ROLLOUT_PID 2>/dev/null; wait $ROLLOUT_PID 2>/dev/null; exit 130" SIGTERM SIGINT
+
+  # Resolve o label selector dos pods associados ao recurso.
+  # Necessário para filtrar apenas os pods deste deploy no loop de monitoramento.
+  # Pods são ignorados aqui pois eles mesmos são monitorados diretamente abaixo.
+  local selector=""
+  if [ "$kind_lower" != "pod" ]; then
+    sleep 2  # Aguarda brevemente para o recurso estar visível na API do Kubernetes.
+    selector=$(kubectl get "$kind_lower" "$resource_name" -n "$namespace" \
+      -o jsonpath='{.spec.selector.matchLabels}' 2>/dev/null \
+      | jq -r 'to_entries | map("\(.key)=\(.value)") | join(",")' 2>/dev/null)
+  fi
+
+  # Loop de monitoramento: verifica a cada 5 segundos enquanto o rollout está rodando.
+  # Estados de falha monitorados:
+  #   - CrashLoopBackOff: container falha repetidamente ao iniciar.
+  #   - OOMKilled: container encerrado por falta de memória.
+  #   - ImagePullBackOff / ErrImagePull: imagem Docker não pode ser baixada.
+  while kill -0 "$ROLLOUT_PID" 2>/dev/null; do
+    local crash_info=""
+    if [ -n "$selector" ]; then
+      # Para Deployments, DaemonSets e ReplicaSets: busca pods pelo selector do recurso.
+      crash_info=$(kubectl get pods -n "$namespace" -l "$selector" --no-headers 2>/dev/null \
+        | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull)" | head -3)
+    elif [ "$kind_lower" == "pod" ]; then
+      # Para Pods standalone: verifica diretamente o status do pod pelo nome.
+      crash_info=$(kubectl get pod "$resource_name" -n "$namespace" --no-headers 2>/dev/null \
+        | grep -E "(CrashLoopBackOff|OOMKilled|ImagePullBackOff|ErrImagePull)" | head -1)
+    fi
+
+    # Se algum pod falhou, interrompe o rollout imediatamente (fail fast).
+    if [ -n "$crash_info" ]; then
+      echo ""
+      echo "ERROR: Pod(s) detected in failed state — failing fast:"
+      echo "$crash_info"
+      kill "$ROLLOUT_PID" 2>/dev/null
+      wait "$ROLLOUT_PID" 2>/dev/null
+      trap - SIGTERM SIGINT
+      return 1
+    fi
+    sleep 5
+  done
+
+  # Aguarda o kubectl terminar e captura o código de saída (0 = sucesso, !0 = falha/timeout).
+  wait "$ROLLOUT_PID"
+  local rollout_exit=$?
+
+  # Remove o trap após o rollout concluir normalmente para não afetar outros comandos.
+  trap - SIGTERM SIGINT
+  return $rollout_exit
+}
+
+# -----------------------------------------------------------------------------
+# artifactType
+#
+# Itera sobre todos os arquivos de um determinado tipo de recurso Kubernetes
+# (ex: todos os Deployments) e chama applyFile para cada um.
+#
+# Parâmetros:
+#   $1 — tipo do recurso (ex: "Deployment", "Service")
+#   $2 — true/false: se deve acompanhar o rollout após o apply
+# -----------------------------------------------------------------------------
 artifactType () {
   local type="$1"
   local kube_rollout="$2"
@@ -206,7 +398,7 @@ artifactType () {
     local file="$(echo -n $json_file | jq -cr '.file')"
     local print_name="$(echo -n $json_file | jq -cr '.print')"
 
-    #Alter files if ENVSUBS=true
+    # Substitui variáveis de ambiente no YAML antes de aplicar, se habilitado.
     if [ "$ENVSUBST" = "true" ]; then
       envSubstitution $file
     fi
@@ -218,6 +410,25 @@ artifactType () {
   done
 }
 
+# -----------------------------------------------------------------------------
+# applyFile
+#
+# Aplica um único manifest YAML no cluster e, opcionalmente, acompanha o
+# rollout do recurso. Registra o resultado no resumo do GitHub Actions.
+#
+# Lógica do rollout:
+#   - "unchanged": o manifest não mudou, mas um rollout restart é forçado
+#     para garantir que a imagem/configuração mais recente seja usada.
+#   - "configured" / "created": o recurso foi atualizado ou criado;
+#     o Kubernetes já iniciará o rollout automaticamente, basta monitorar.
+#
+# Parâmetros:
+#   $1 — caminho do arquivo YAML
+#   $2 — nome original do arquivo (para exibição no resumo)
+#   $3 — índice do arquivo dentro do tipo (para formatação da tabela)
+#   $4 — tipo do recurso (ex: "Deployment")
+#   $5 — true/false: se deve monitorar o rollout
+# -----------------------------------------------------------------------------
 applyFile () {
   local file="$1"
   local print_name="$2"
@@ -225,16 +436,18 @@ applyFile () {
   local type="$4"
   local kube_rollout="$5"
 
-  #Printa em branco na primeira tabela caso seja outro arquivo do mesmo tipo
+  # Deixa a célula de tipo em branco para arquivos subsequentes do mesmo tipo,
+  # evitando repetição na tabela de resumo do GitHub Actions.
   if [ $tmp_count -gt 0 ]; then
     echo -n "| | " >> $GITHUB_STEP_SUMMARY
   fi
 
-  #Resource Name
+  # Extrai o nome do recurso do manifest para exibição no resumo.
   local resource_name=$(echo -n "$(yq eval '.metadata.name' $file)")
   echo -n "$resource_name" >> $GITHUB_STEP_SUMMARY
 
-  #Applying artifact
+  # Aplica o manifest no cluster e captura a saída para determinar o estado
+  # (created / configured / unchanged) e decidir o comportamento do rollout.
   echo "Applying file: $file"
   echo "Original file: $print_name"
   echo -n " | $print_name" >> $GITHUB_STEP_SUMMARY
@@ -246,7 +459,7 @@ applyFile () {
     echo " | Failed :x: |" >> $GITHUB_STEP_SUMMARY
     echo "KUBE_EXIT_CODE: $KUBE_EXIT_CODE"
     echo "KUBECTL_OUTPUT: $KUBE_APPLY"
-    #Para a action caso o esteja setado CONTINUE_IF_FAIL=false
+    # Interrompe o script se CONTINUE_IF_FAIL=false (comportamento padrão).
     if ! $CONTINUE_IF_FAIL; then
       exit 1
     fi
@@ -254,39 +467,44 @@ applyFile () {
     echo "Arquivo aplicado com sucesso: $file"
     echo " | Passed :white_check_mark: |" >> $GITHUB_STEP_SUMMARY
   fi
-  
-  #Verify and execute rollout
+
+  # Acompanha o rollout apenas para recursos que gerenciam Pods
+  # (Deployment, DaemonSet, ReplicaSet, Pod) e quando KUBE_ROLLOUT=true.
   if [ "$kube_rollout" == true ]; then
     echo "============================="
     echo ""
     echo "============================="
 
-    #Timestamp do início da execução do kuberollout
+    # Registra o timestamp de início para calcular o tempo de execução do rollout.
     local kube_rollout_start_time=$(date +%s)
 
     if [ "$(echo $KUBE_APPLY |sed 's/.* //')" == "unchanged" ]; then
+      # Recurso sem alteração no manifest: força um restart para que a imagem
+      # ou configuração mais recente (ex: nova tag via ENVSUBST) seja aplicada.
       echo "Applying rollout:"
       kubectl rollout restart --filename $file
       echo ""
       echo "Checking rollout status:"
-      kubectl rollout status --filename $file --timeout=$KUBE_ROLLOUT_TIMEOUT
-      local kube_rollout_status=$?  # Captura o código de saída do último comando
+      run_rollout_status "$file" "$type" "$resource_name"
+      local kube_rollout_status=$?
     elif ([ "$(echo $KUBE_APPLY |sed 's/.* //')" == "configured" ] || [ "$(echo $KUBE_APPLY |sed 's/.* //')" == "created" ]); then
+      # Recurso atualizado ou criado: o Kubernetes já iniciou o rollout;
+      # apenas monitora até a conclusão ou falha.
       echo "Checking rollout status:"
-      kubectl rollout status --filename $file --timeout=$KUBE_ROLLOUT_TIMEOUT
-      local kube_rollout_status=$?  # Captura o código de saída do último comando
+      run_rollout_status "$file" "$type" "$resource_name"
+      local kube_rollout_status=$?
     fi
 
-    #Timestamp do fim da execução do kuberollout
+    # Registra o timestamp de fim e calcula o tempo total do rollout.
     local kube_rollout_end_time=$(date +%s)
 
     # Calcula o tempo total de execução em segundos
     local kube_rollout_execution_time=$((kube_rollout_end_time - kube_rollout_start_time))
-    
+
     # Converte o tempo total em minutos e segundos
     local minutes=$((kube_rollout_execution_time / 60))
     local seconds=$((kube_rollout_execution_time % 60))
-    
+
     # Verifica se o comando foi bem-sucedido
     if [ $kube_rollout_status -eq 0 ]; then
         echo "O rollout foi bem-sucedido."
@@ -296,8 +514,10 @@ applyFile () {
         local kube_rollout_mark=false
     fi
 
+    # Salva o resultado do rollout no array JSON para ser exibido na tabela
+    # de resumo do GitHub Actions ao final do script.
     KUBE_ROLLOUT_JSON+=("{\"type\":\"$type\",\"file\":\"$print_name\",\"resource_name\":\"$resource_name\",\"time\":\"${minutes}m:${seconds}s\",\"status\":$kube_rollout_mark}")
-    
+
     # Exibe o tempo total de execução no formato Xm:Xs
     echo "Tempo de execução: ${minutes}m:${seconds}s."
   fi
@@ -308,37 +528,51 @@ applyFile () {
 }
 
 ###===========================================================
-###===========================================================
+# INÍCIO DA EXECUÇÃO
 ###===========================================================
 
-#Transformando os inputs do githubaciotns em array
+# -----------------------------------------------------------------------------
+# Preparação dos inputs.
+# FILES_PATH e KUBE_YAML podem conter múltiplos valores separados por vírgula;
+# aqui eles são convertidos em arrays bash para iteração.
+# -----------------------------------------------------------------------------
 IFS=',' read -r -a FT_FILES_PATH <<< "$FILES_PATH"
 IFS=',' read -r -a FT_KUBE_YAML <<< "$KUBE_YAML"
 
-#Recebe os arquivos e os status dos rollouts
+# Array que acumula o resultado JSON de cada rollout para a tabela de resumo.
 KUBE_ROLLOUT_JSON=()
 
-#Recebe o status do rollout
+# Flag global que indica se algum rollout falhou; usada ao final para
+# decidir se o script deve sair com erro mesmo após processar todos os recursos.
 KUBE_ROLLOUT_FAILED=false
 
-#Valida se os paths existem
+# -----------------------------------------------------------------------------
+# Validação dos paths e arquivos informados pelo usuário.
+# -----------------------------------------------------------------------------
+
+# Valida se os paths existem e contêm arquivos YAML.
 if [ ${#FT_FILES_PATH[@]} -gt 0 ]; then
   check_directories_and_files ${FT_FILES_PATH[@]}
 fi
 
-#Valida se os arquivos existem e possuem extensões válidas
+# Valida se os arquivos individuais existem e possuem extensões válidas.
 if [ ${#FT_KUBE_YAML[@]} -gt 0 ]; then
   check_files_exist ${FT_KUBE_YAML[@]}
 fi
 
-# Loop para iterar sobre cada item no vetor
+# Remove a barra final de cada diretório informado, caso exista,
+# para evitar caminhos duplicados (ex: "k8s//" ao concatenar com "/arquivo.yaml").
 for i in "${!FT_FILES_PATH[@]}"; do
   if [[ "${FT_FILES_PATH[$i]}" == */ ]]; then
-    # Remove a barra (/) do final
     FT_FILES_PATH[$i]="${FT_FILES_PATH[$i]%/}"
   fi
 done
 
+# -----------------------------------------------------------------------------
+# Descoberta dos arquivos YAML.
+# Coleta todos os arquivos .yaml/.yml dos diretórios informados e os une
+# com os arquivos individuais especificados em KUBE_YAML.
+# -----------------------------------------------------------------------------
 for j in "${!FT_FILES_PATH[@]}"; do
   #Lista de arquivos
   FILES_YAML+=($(find ${FT_FILES_PATH[$j]} -type f \( -name "*.yml" -o -name "*.yaml" \) | paste -sd ' ' -))
@@ -346,14 +580,19 @@ done
 
 FILES_JSON='{}'
 
-#Adiciona arquivos individuais setados pelo usuário
+# Inclui os arquivos individuais de KUBE_YAML junto aos encontrados nos diretórios.
 FILES_YAML+=("${FT_KUBE_YAML[@]}")
 
-#Percorre os arquivos para montar o FILES_JSON com os arquivos
+# -----------------------------------------------------------------------------
+# Classificação dos arquivos por tipo de recurso Kubernetes (FILES_JSON).
+# Cada arquivo é lido, seu .kind extraído e registrado em FILES_JSON, que
+# serve como índice para a aplicação ordenada na próxima etapa.
+# Se SUBPATH=false, arquivos em subdiretórios além do informado são ignorados.
+# -----------------------------------------------------------------------------
 for i in ${FILES_YAML[@]}; do
 
   if $SUBPATH; then
-    #cria Json com todos os arquivos do diretório e sub-diretório
+    # SUBPATH=true: inclui arquivos em qualquer nível de subdiretório.
     createJsonFiles $i
   else
     #Quantidade total de subpath no arquivo a ser aplicado
@@ -367,15 +606,15 @@ for i in ${FILES_YAML[@]}; do
         qtd_subpath=$(echo "$file_no_path" | tr -cd '/' | wc -c | tr -d ' ')
       fi
     done
-    #se FILES_PATH não é nulo, pois se for, não precisa chamar createJsonFiles
+    # SUBPATH=false: ignora arquivos que estejam em sub-diretórios além do informado.
     if [ -n "$FILES_PATH" ]; then
-      #Verifica se tem mais sub-diretórios além do informado
       if [ $qtd_subpath -gt 0 ]; then
         echo "SUBPATH=false. Ignoring file: $i"
       else
         createJsonFiles $i
       fi
     else
+      # KUBE_YAML foi informado diretamente (sem FILES_PATH): inclui o arquivo.
       createJsonFiles $i
     fi
   fi
@@ -383,6 +622,7 @@ done
 
 echo ""
 
+# Inicia a tabela de status de deploy no resumo do GitHub Actions.
 echo "## Deploy Status" >> $GITHUB_STEP_SUMMARY
 
 echo "| Type        | Resource Name  | File    | Status  |" >> $GITHUB_STEP_SUMMARY
@@ -392,13 +632,22 @@ echo "Files to apply:"
 echo $FILES_JSON | jq
 echo "============================="
 
+# -----------------------------------------------------------------------------
+# Aplicação dos manifests na ordem de dependência correta:
+#
+#   1. Namespace — deve existir antes de qualquer outro recurso.
+#   2. Recursos sem Pods (ConfigMap, Service, Ingress, etc.) — sem rollout.
+#   3. Recursos com Pods (Deployment, DaemonSet, ReplicaSet, Pod) — com rollout.
+#   4. ScaledObject (KEDA) — deve ser aplicado por último pois depende do
+#      Deployment existir para não falhar.
+# -----------------------------------------------------------------------------
 
-#Verifica se tem artefatos do tipo Namespace para aplicar primeiro
+# Passo 1: aplica Namespaces primeiro (sem rollout, pois não possuem Pods).
 if echo -n "$FILES_JSON" | jq -e '.Namespace' > /dev/null; then
   artifactType "Namespace" false
 fi
 
-#Percorre todos os tipos de artefatos
+# Passo 2: aplica todos os demais tipos que não são Pods nem ScaledObject.
 for type in $(echo -n "$FILES_JSON" | jq -cr 'keys[]'); do
   #Verifica se o type não é o tipo Namespace, que já foi aplicado, e se não são artefatos que contém pod para aplicar por último
   if [[ "$type" != "Namespace" ]] && \
@@ -411,7 +660,8 @@ for type in $(echo -n "$FILES_JSON" | jq -cr 'keys[]'); do
   fi
 done
 
-#Aplica os artefatos que tem Pods
+# Passo 3: aplica os recursos que gerenciam Pods, habilitando o rollout
+# quando KUBE_ROLLOUT=true para acompanhar a subida dos containers.
 pods_artifacts=(
   "Deployment"
   "ReplicaSet"
@@ -429,7 +679,9 @@ for type in ${pods_artifacts[@]}; do
   fi
 done
 
-#Aplica por último. Necessário por o keda(ScaledObject) quebra se o deployment não existir
+# Passo 4: aplica ScaledObject por último (KEDA).
+# O ScaledObject referencia um Deployment existente; aplicá-lo antes
+# do Deployment causar ia erro no KEDA.
 last_apply=(
   "ScaledObject"
 )
@@ -440,28 +692,32 @@ for type in ${last_apply[@]}; do
   fi
 done
 
-#Finaliza a primeira tabela
+# Fecha a tabela de deploy no resumo do GitHub Actions.
 echo "" >> $GITHUB_STEP_SUMMARY
 
-#Verifica KUBE_ROLLOUT para printar tabela
+# -----------------------------------------------------------------------------
+# Tabela de rollout no resumo do GitHub Actions.
+# Exibida apenas quando KUBE_ROLLOUT=true; mostra tipo, nome, arquivo,
+# tempo de execução e status (Passed/Failed) de cada rollout realizado.
+# -----------------------------------------------------------------------------
 if [ "$KUBE_ROLLOUT" == "true" ]; then
-  
+
   echo "---" >> $GITHUB_STEP_SUMMARY
-  
+
   echo "## Rollout Status" >> $GITHUB_STEP_SUMMARY
-  
+
   echo "| Type        | Resource Name  | File            | Execution Time  | Status  |" >> $GITHUB_STEP_SUMMARY
   echo "|-------------|----------------|-----------------|-----------------|---------|" >> $GITHUB_STEP_SUMMARY
 
-  #Iterage sobre o JSON para preencher a tabela
+  # Itera sobre o array KUBE_ROLLOUT_JSON acumulado durante os applies.
   for e in ${KUBE_ROLLOUT_JSON[@]}; do
-  
+
     kr_type="$(echo -n $e | jq -r .type)"
     kr_resource_name="$(echo -n $e | jq -r .resource_name)"
     kr_file="$(echo -n $e | jq -r .file)"
     kr_time="$(echo -n $e | jq -r .time)"
     kr_status="$(echo -n $e | jq -r .status)"
-  
+
     echo -n "| $kr_type " >> $GITHUB_STEP_SUMMARY
     echo -n "| $kr_resource_name " >> $GITHUB_STEP_SUMMARY
     echo -n "| $kr_file " >> $GITHUB_STEP_SUMMARY
@@ -471,17 +727,18 @@ if [ "$KUBE_ROLLOUT" == "true" ]; then
     else
       echo "| Failed :x: |" >> $GITHUB_STEP_SUMMARY
       KUBE_ROLLOUT_FAILED=true
-      #Para a action caso o esteja setado CONTINUE_IF_FAIL=false
+      # Interrompe imediatamente se CONTINUE_IF_FAIL=false.
       if ! $CONTINUE_IF_FAIL; then
         exit 1
       fi
     fi
-  
+
   done
-  
+
 fi
 
-#Quebra a pipe caso algum rollout tenha falhado
+# Se algum rollout falhou e CONTINUE_IF_FAIL=true (script chegou até aqui),
+# garante que o exit code final seja 1 para sinalizar falha ao GitHub Actions.
 if $KUBE_ROLLOUT_FAILED; then
   exit 1
 fi


### PR DESCRIPTION
## Summary

This PR improves rollout monitoring with three fixes and one new feature.

### 1. Workflow cancellation now works from the GitHub Actions UI

Previously, `kubectl rollout status` ran in the foreground, blocking the script from receiving signals. Cancelling the workflow from the GitHub Actions UI had no effect during a rollout — the step kept running until it finished naturally.

**Fix:** `kubectl rollout status` now runs in the background. A `trap` on `SIGTERM` and `SIGINT` kills the background process and exits immediately when GitHub Actions cancels the workflow.

---

### 2. CrashLoopBackOff detection during rollout (fail fast)

Previously, the pipeline waited the full `KUBE_ROLLOUT_TIMEOUT` (default: 20 minutes) before failing when pods entered a crash state.

**Fix:** A monitoring loop runs every 3 seconds in parallel with the rollout. If any pod from the **new** ReplicaSet enters a failed state, the rollout is killed immediately and the pipeline fails without waiting for the timeout.

States monitored: `CrashLoopBackOff`, `OOMKilled`, `ImagePullBackOff`, `ErrImagePull`, `Error`.

---

### 3. Post-rollout stability check (`KUBE_STABILITY_WINDOW`)

Kubernetes marks a pod as "ready" as soon as the container process starts — before the application has time to crash. In this scenario, `kubectl rollout status` reports success while pods are already silently crashing in the background.

**Fix:** After the rollout reports success, the action waits `KUBE_STABILITY_WINDOW` seconds (default: `15`) and re-checks all pods of the new ReplicaSet. If any pod is in a failed state, the pipeline fails.

New optional env:

| ENV | Type | Default | Description |
|---|---|---|---|
| `KUBE_STABILITY_WINDOW` | integer | `15` | Seconds to wait after rollout success before the final pod health check. Should be greater than the application's startup time. |

---

### 4. False positives from old ReplicaSet pods

When a new rollout starts while the previous ReplicaSet's pods are still in `CrashLoopBackOff` and terminating, the monitoring loop was matching both old and new pods via the Deployment's label selector (e.g. `app=my-app`). This caused the pipeline to fail even when the new pods were healthy.

**Fix:** For Deployments, the action now resolves the `pod-template-hash` of the current ReplicaSet by matching the `deployment.kubernetes.io/revision` annotation. All health checks (monitoring loop and stability check) use a scoped selector (e.g. `app=my-app,pod-template-hash=7d7b65d479`) that targets only the new ReplicaSet's pods.

If the hash cannot be resolved (permissions, timing, non-Deployment resource), the full label selector is used as a fallback — preserving existing behaviour for `DaemonSet`, `ReplicaSet`, and `Pod`.

---

## Test plan

- [ ] Deploy a healthy application → pipeline passes, stability check passes
- [ ] Deploy an application that crashes immediately → pipeline fails fast during rollout (monitoring loop)
- [ ] Deploy an application that crashes after startup (e.g. `TIME_TO_CRASH=10`) → pipeline fails at stability check
- [ ] Cancel the workflow during a rollout → step stops immediately
- [ ] Trigger a new healthy rollout while old pods are in `CrashLoopBackOff` → pipeline passes without false positive
