### PR TITLE
Keyless authentication: ambient AWS credentials + runtime kubeconfig via CLUSTER_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,39 @@ Point to a file or directory, and this action will apply your manifests, monitor
 <br>
 
 # Example
+
+Keyless (recommended) — OIDC via [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials), no long-lived secrets:
 ```yml
-name: Build
+name: Deploy
 
 on:
   push:
     branches: [ main ]
 
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::111122223333:role/my-deploy-role
+          aws-region: us-east-1
+      - name: Deployment
+        uses: Pablommr/kubernetes-eks@v2.2.0
+        env:
+          CLUSTER_NAME: my-eks-cluster
+          KUBE_YAML: path_to_file/file.yml
+```
+
+Classic — static access key + base64 kubeconfig (still fully supported):
+```yml
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -21,7 +47,7 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v4
       - name: Deployment
-        uses: Pablommr/kubernetes-eks@v2.1.2
+        uses: Pablommr/kubernetes-eks@v2.2.0
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -33,7 +59,7 @@ jobs:
 
 # Usage
 
-To use this action you need an IAM user with permission to apply resources in your EKS cluster. For more information, see the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html).
+You need an AWS identity with permission to apply resources in your EKS cluster — either an IAM role assumed via OIDC (keyless, recommended) or an IAM user with static keys. For more information, see the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html).
 
 Set up the environment variables listed below and point to your manifest files via `KUBE_YAML` (individual files) or `FILES_PATH` (directory).
 
@@ -41,19 +67,23 @@ Set up the environment variables listed below and point to your manifest files v
 
 # ENV's
 
+## Authentication
+
+### AWS credentials — two ways
+
+**Ambient credentials (keyless, recommended)** — leave `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` unset and the action uses whatever credentials are already available in the environment: the temporary credentials exported by `aws-actions/configure-aws-credentials` (OIDC), an instance role on a self-hosted runner, etc. Nothing is written to disk.
+
+**Static keys** — set `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (and optionally `AWS_SESSION_TOKEN` for temporary STS credentials). They are written to `~/.aws/credentials` under `AWS_PROFILE_NAME`, exactly as before.
+
+In both cases the action validates the identity with `aws sts get-caller-identity` before applying anything, and logs the effective ARN for auditability.
+
+### Cluster access — two ways
+
+**`CLUSTER_NAME` (keyless, recommended)** — the kubeconfig is generated at runtime with `aws eks update-kubeconfig`. Requires the cluster region in `AWS_REGION` (or `AWS_DEFAULT_REGION`). No `KUBECONFIG` secret needed.
+
+**`KUBECONFIG`** — base64-encoded kubeconfig file, as before. The profile name inside the kubeconfig must match `AWS_PROFILE_NAME`.
+
 ## Required
-
-### `AWS_ACCESS_KEY_ID`
-
-AWS access key ID for the IAM role used to authenticate with the cluster.
-
-### `AWS_SECRET_ACCESS_KEY`
-
-AWS secret access key for the IAM role.
-
-### `KUBECONFIG`
-
-Base64-encoded kubeconfig file. The profile name inside the kubeconfig must match `AWS_PROFILE_NAME`.
 
 ### `KUBE_YAML` or `FILES_PATH`
 
@@ -75,7 +105,15 @@ FILES_PATH: kubernetes
 
 ### `AWS_PROFILE_NAME`
 
-AWS credentials profile name to be written to `~/.aws/credentials`. Defaults to `default`.
+AWS credentials profile name to be written to `~/.aws/credentials`. Defaults to `default`. Only used with static keys — ignored with ambient credentials.
+
+### `AWS_SESSION_TOKEN`
+
+Session token for temporary STS credentials, written to `~/.aws/credentials` alongside the keys. Only relevant with static keys — ambient credentials carry their own token.
+
+### `AWS_REGION`
+
+Cluster region, required when using `CLUSTER_NAME` (falls back to `AWS_DEFAULT_REGION`). Already exported automatically by `aws-actions/configure-aws-credentials`.
 
 ### `ENVSUBST`
 `boolean` — default: `false`
@@ -220,6 +258,14 @@ With `FILES_PATH: kubernetes` and `SUBPATH: false`, only `deployment.yaml` and `
 <br>
 
 # Change Log
+
+## v2.2.0
+
+- Keyless authentication: `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are now optional — when unset, the action uses ambient credentials (e.g. OIDC temporary credentials exported by `aws-actions/configure-aws-credentials`, or an instance role). Nothing is written to disk in this mode.
+- Runtime kubeconfig: new `CLUSTER_NAME` env generates the kubeconfig via `aws eks update-kubeconfig` (requires `AWS_REGION`/`AWS_DEFAULT_REGION`), removing the need for a base64 `KUBECONFIG` secret.
+- `AWS_SESSION_TOKEN` support when writing static credentials, enabling temporary STS keys in the classic mode.
+- Fail-fast identity check: `aws sts get-caller-identity` runs before any apply and the effective ARN is logged for auditability.
+- Fully backward compatible: existing setups (keys + `KUBECONFIG`) behave exactly as before.
 
 ## v2.1.2
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Deployment
         uses: Pablommr/kubernetes-eks@v2.2.0
         env:
@@ -240,7 +240,7 @@ jobs:
     needs: build_and_push
     steps:
       - name: Checkout 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Deploy
         uses: Pablommr/kubernetes-eks@v2.1.2
         env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,20 +19,48 @@ echo ""
 echo "Checking ENVs..."
 
 # -----------------------------------------------------------------------------
-# Validação das variáveis de ambiente obrigatórias.
-# O script falha imediatamente se qualquer uma delas estiver ausente,
-# pois sem elas não é possível autenticar na AWS nem no cluster.
+# Validação das variáveis de ambiente e detecção do modo de autenticação.
+#
+# CREDENCIAIS AWS — duas formas:
+#   - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY definidos -> grava o
+#     ~/.aws/credentials como sempre (incluindo aws_session_token quando
+#     AWS_SESSION_TOKEN existir, necessário para credenciais temporárias STS).
+#   - Ambos vazios -> usa as credenciais ambientes do processo (ex.: exportadas
+#     por aws-actions/configure-aws-credentials via OIDC keyless, instance
+#     role, etc). Nada é gravado em disco.
+#
+# KUBECONFIG — duas formas:
+#   - CLUSTER_NAME definido -> o kubeconfig é GERADO em runtime via
+#     `aws eks update-kubeconfig` (requer região em AWS_REGION ou
+#     AWS_DEFAULT_REGION). Dispensa a env KUBECONFIG.
+#   - CLUSTER_NAME vazio    -> comportamento original: KUBECONFIG em base64.
+#
+# Retrocompatibilidade: chamadas existentes (keys + KUBECONFIG, sem
+# CLUSTER_NAME) seguem o fluxo original sem nenhuma mudança de comportamento.
 # -----------------------------------------------------------------------------
-if [ -z "$AWS_ACCESS_KEY_ID" ]; then
-  echo 'Env AWS_ACCESS_KEY_ID is empty! Please, fulfil it with your aws access key...'
+
+# Credenciais: ou o par completo de keys, ou nenhuma (credenciais ambientes).
+if [ -n "$AWS_ACCESS_KEY_ID" ] && [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo 'Env AWS_SECRET_ACCESS_KEY is empty! Fulfil it with your aws access secret, or unset AWS_ACCESS_KEY_ID to use ambient credentials...'
   exit 1
-elif [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-  echo 'Env AWS_SECRET_ACCESS_KEY is empty! Please, fulfil  with your aws access secret...'
+elif [ -z "$AWS_ACCESS_KEY_ID" ] && [ -n "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo 'Env AWS_ACCESS_KEY_ID is empty! Fulfil it with your aws access key, or unset AWS_SECRET_ACCESS_KEY to use ambient credentials...'
   exit 1
-elif [ -z "$KUBECONFIG" ]; then
-  echo 'Env KUBECONFIG is empty! Please, fulfil it with your kubeconfig in base64...'
+fi
+
+# Kubeconfig: gerado em runtime (CLUSTER_NAME) ou fornecido em base64 (KUBECONFIG).
+if [ -z "$CLUSTER_NAME" ] && [ -z "$KUBECONFIG" ]; then
+  echo 'Envs CLUSTER_NAME and KUBECONFIG are empty! Fulfil CLUSTER_NAME (kubeconfig generated at runtime via `aws eks update-kubeconfig`) or KUBECONFIG (base64)...'
   exit 1
-elif [ -z "$KUBE_YAML" ]; then
+fi
+
+# update-kubeconfig exige uma região explícita.
+if [ -n "$CLUSTER_NAME" ] && [ -z "$AWS_REGION" ] && [ -z "$AWS_DEFAULT_REGION" ]; then
+  echo 'Env CLUSTER_NAME is set but AWS_REGION (or AWS_DEFAULT_REGION) is empty! Fulfil it with the cluster region...'
+  exit 1
+fi
+
+if [ -z "$KUBE_YAML" ]; then
   # Aceita FILES_PATH como alternativa a KUBE_YAML para apontar um diretório inteiro.
   if [ -z "$FILES_PATH" ]; then
     echo "Envs KUBE_YAML or FILES_PATH is empty or file doesn't exist! Please, fulfil it with full path where your file is..."
@@ -106,26 +134,59 @@ fi
 echo ""
 
 # -----------------------------------------------------------------------------
-# Configuração das credenciais AWS e do kubeconfig.
-# Os valores chegam como variáveis de ambiente e são gravados nos paths
-# esperados pelo AWS CLI e pelo kubectl, respectivamente.
+# Configuração das credenciais AWS e do kubeconfig, conforme o modo detectado
+# na validação acima.
 # -----------------------------------------------------------------------------
 mkdir -p ~/.aws
 mkdir -p ~/.kube
 
-AWS_CREDENTIALS_PATH='~/.aws/credentials'
 KUBECONFIG_PATH='~/.kube/config'
 
-# Grava o arquivo de credenciais AWS com o perfil configurado.
-echo "[$AWS_PROFILE_NAME]" > $(eval echo $AWS_CREDENTIALS_PATH)
-echo "aws_access_key_id = $AWS_ACCESS_KEY_ID" >> $(eval echo $AWS_CREDENTIALS_PATH)
-echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY" >> $(eval echo $AWS_CREDENTIALS_PATH)
+# Credenciais: grava o arquivo apenas quando as keys foram fornecidas.
+# Sem keys, o AWS CLI resolve as credenciais ambientes (env/role) sozinho —
+# nada é gravado em disco.
+if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+  AWS_CREDENTIALS_PATH='~/.aws/credentials'
+  echo "[$AWS_PROFILE_NAME]" > $(eval echo $AWS_CREDENTIALS_PATH)
+  echo "aws_access_key_id = $AWS_ACCESS_KEY_ID" >> $(eval echo $AWS_CREDENTIALS_PATH)
+  echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY" >> $(eval echo $AWS_CREDENTIALS_PATH)
+  # Credenciais temporárias (STS/OIDC) só funcionam com o session token junto.
+  if [ -n "$AWS_SESSION_TOKEN" ]; then
+    echo "aws_session_token = $AWS_SESSION_TOKEN" >> $(eval echo $AWS_CREDENTIALS_PATH)
+  fi
+  echo "AWS credentials: keys written to profile [$AWS_PROFILE_NAME]."
+else
+  echo 'AWS credentials: none provided, using ambient credentials (env/role).'
+fi
 
-# Decodifica o kubeconfig (enviado em base64) e salva no path padrão do kubectl.
-echo "$KUBECONFIG" |base64 -d > $(eval echo $KUBECONFIG_PATH)
+# Falha rápido, com mensagem clara, se não há credencial utilizável — e loga a
+# identidade efetiva (útil para auditoria do deploy).
+CALLER_IDENTITY=$(aws sts get-caller-identity --query Arn --output text 2>&1)
+if [ $? -ne 0 ]; then
+  echo 'Unable to authenticate on AWS! Check your credentials (keys or ambient). Error:'
+  echo "$CALLER_IDENTITY"
+  exit 1
+fi
+echo "Authenticated on AWS as: $CALLER_IDENTITY"
 
-# Remove a variável KUBECONFIG do ambiente para evitar conflito com o arquivo gravado acima.
-unset KUBECONFIG
+if [ -n "$CLUSTER_NAME" ]; then
+  # Gera o kubeconfig em runtime a partir do cluster — dispensa o KUBECONFIG
+  # em base64 (e o risco de um kubeconfig eterno vazar junto com secrets).
+  REGION="${AWS_REGION:-$AWS_DEFAULT_REGION}"
+  echo "Generating kubeconfig via aws eks update-kubeconfig ($CLUSTER_NAME @ $REGION)..."
+  unset KUBECONFIG
+  aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "$REGION" --kubeconfig $(eval echo $KUBECONFIG_PATH)
+  if [ $? -ne 0 ]; then
+    echo "Failed to generate kubeconfig for cluster $CLUSTER_NAME!"
+    exit 1
+  fi
+else
+  # Decodifica o kubeconfig (enviado em base64) e salva no path padrão do kubectl.
+  echo "$KUBECONFIG" |base64 -d > $(eval echo $KUBECONFIG_PATH)
+
+  # Remove a variável KUBECONFIG do ambiente para evitar conflito com o arquivo gravado acima.
+  unset KUBECONFIG
+fi
 
 
 ###================================


### PR DESCRIPTION
## Summary

Adds keyless authentication support to the action, eliminating the need for
long-lived AWS access keys and a baked base64 kubeconfig — while remaining 100%
backward compatible with existing setups.

Static access keys stored as GitHub secrets are a permanent exfiltration risk:
they never expire, and anyone who obtains them can use them from anywhere. With
GitHub OIDC + `aws-actions/configure-aws-credentials`, each workflow run gets
temporary credentials (~1h) and nothing sensitive is stored in the repo. This PR
makes the action work natively with that flow.

## What changed

### 1. AWS credentials are now optional (ambient credentials support)
- `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` set → written to
  `~/.aws/credentials` under `AWS_PROFILE_NAME`, exactly as before.
- Both unset → the action uses whatever credentials are already available in
  the environment (e.g. temporary credentials exported by
  `aws-actions/configure-aws-credentials` via OIDC, or an instance role on a
  self-hosted runner). Nothing is written to disk.
- Setting only one of the two keys fails fast with a clear message.

### 2. `AWS_SESSION_TOKEN` support
When writing static credentials, `aws_session_token` is now included if
present. This fixes temporary STS credentials in the classic mode — previously
the token was silently dropped, making temporary keys unusable.

### 3. Runtime kubeconfig via new `CLUSTER_NAME` env
- `CLUSTER_NAME` set → the kubeconfig is generated at runtime with
  `aws eks update-kubeconfig` (requires `AWS_REGION` or `AWS_DEFAULT_REGION`).
  No more base64 `KUBECONFIG` secret.
- `CLUSTER_NAME` unset → original behavior (`KUBECONFIG` in base64) unchanged.

### 4. Fail-fast identity check
`aws sts get-caller-identity` runs before any apply. If no usable credentials
exist, the action fails immediately with an actionable message instead of a
cryptic kubectl error later — and the effective identity ARN is logged, which
is useful for deploy auditability.

## Backward compatibility

Existing setups (keys + `KUBECONFIG`, no `CLUSTER_NAME`) follow the exact same
code path as before. The only observable differences are the new
`Authenticated on AWS as: <arn>` log line and the identity pre-check.

## Minimal keyless example

```yml
permissions:
  id-token: write
  contents: read

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v5
      - uses: aws-actions/configure-aws-credentials@v6
        with:
          role-to-assume: arn:aws:iam::111122223333:role/my-deploy-role
          aws-region: us-east-1
      - uses: Pablommr/kubernetes-eks@v2.2.0
        env:
          CLUSTER_NAME: my-eks-cluster
          KUBE_YAML: kubernetes/deployment.yml
```

## Validation

- Validation matrix tested for all env combinations: missing everything,
  partial keys, `CLUSTER_NAME` without region, valid keyless, valid classic —
  each fails/passes at the expected point with the expected message.
- End-to-end test on a real EKS cluster via GitHub OIDC: role assumed with
  temporary credentials, kubeconfig generated at runtime, namespace +
  deployment applied, rollout monitored to completion (`bash -n` clean).
- Classic mode regression: keys + base64 kubeconfig path unchanged.

## Docs

README updated: keyless example first, new "Authentication" section describing
the two credential modes and the two cluster-access modes, docs for
`CLUSTER_NAME`, `AWS_REGION` and `AWS_SESSION_TOKEN`, changelog entry.

Suggested release: **v2.2.0** (additive, no breaking changes).
